### PR TITLE
Add compression middleware back

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { ConfigProvider } from '@kapeta/sdk-config';
-import express, { Express, Router } from 'express';
+import express, { Express, Request, Response, Router } from 'express';
+import compression from 'compression';
 import Config from '@kapeta/sdk-config';
 import { applyWebpackHandlers } from './src/webpack';
 
@@ -44,6 +45,9 @@ export class Server {
 
         //Configure health endpoint as first route
         this._configureHealthCheck();
+
+        //Configure compression
+        this._configureCompression();
     }
 
     /**
@@ -135,5 +139,19 @@ export class Server {
                 resolve(null);
             });
         });
+    }
+
+    private _configureCompression() {
+        function shouldCompress(req: Request, res: Response) {
+            if (req.headers['x-no-compression']) {
+                // Don't compress responses with this request header
+                return false;
+            }
+
+            // Fallback to standard filter function
+            return compression.filter(req, res);
+        }
+
+        this._express.use(compression({ filter: shouldCompress }));
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
             "license": "MIT",
             "dependencies": {
                 "body-parser": "1.19.0",
+                "compression": "^1.7.4",
                 "express": "4.17.1"
             },
             "devDependencies": {
                 "@kapeta/eslint-config": "^0.6.0",
                 "@kapeta/prettier-config": "^0.6.0",
                 "@kapeta/sdk-config": "<2",
+                "@types/compression": "^1.7.3",
                 "@types/express": "^4.17.2",
                 "eslint": "^8.42.0",
                 "eslint-config-prettier": "^8.8.0",
@@ -288,6 +290,15 @@
             "dependencies": {
                 "@types/connect": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/compression": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.3.tgz",
+            "integrity": "sha512-rKquEGjebqizyHNMOpaE/4FdYR5VQiWFeesqYfvJU0seSEyB4625UGhNOO/qIkH10S3wftiV7oefc8WdLZ/gCQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/express": "*"
             }
         },
         "node_modules/@types/connect": {
@@ -1270,6 +1281,55 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "peer": true
+        },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dependencies": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -3300,6 +3360,14 @@
             "dependencies": {
                 "ee-first": "1.1.1"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
             "engines": {
                 "node": ">= 0.8"
             }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     },
     "dependencies": {
         "body-parser": "1.19.0",
+        "compression": "^1.7.4",
         "express": "4.17.1"
     },
     "peerDependencies": {
@@ -82,6 +83,7 @@
         "@kapeta/eslint-config": "^0.6.0",
         "@kapeta/prettier-config": "^0.6.0",
         "@kapeta/sdk-config": "<2",
+        "@types/compression": "^1.7.3",
         "@types/express": "^4.17.2",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
Whenever we have figured out what else is compressing our payloads we can add compression middleware back.

Reverts kapetacom/sdk-nodejs-server#5