### PR TITLE
Change webpack setup to pre-route middleware [CORE-1745]

### DIFF
--- a/express.d.ts
+++ b/express.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
+/// <reference types="express" />
+
+declare namespace Express {
+    // Extend the express Response object to include renderPage and setRenderValue
+    export interface Response {
+        /**
+         * Renders the application template with information about
+         *
+         *
+         *
+         * @param viewName The name of the view to render.
+         * @param options The options to pass to the view.
+         */
+        renderPage(viewName: string, options?: any): void;
+
+        setRenderValue(key: string, value: any): void;
+        setRenderValue(obj: { [key: string]: any }): void;
+    }
+}

--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,6 @@ export class Server {
         applyWebpackHandlers(distFolder, webpackConfig, this._express, templateOverrides);
     }
 
-
     /**
      * Starts server
      */
@@ -109,7 +108,7 @@ export class Server {
     }
 
     protected configureErrorHandler() {
-        this._express.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+        this._express.use(<express.ErrorRequestHandler>((err, _req, res, next) => {
             if (res.headersSent) {
                 next(err);
                 return;
@@ -121,11 +120,11 @@ export class Server {
             }
 
             res.status(500).json(errorBody);
-        });
+        }));
     }
 
     protected configureCatchAll() {
-        this._express.use((req, res) => {
+        this._express.use((_req, res) => {
             if (!res.headersSent) {
                 res.status(418).json({ error: 'Not available' });
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kapeta/sdk-server",
-    "version": "3.2.0",
+    "version": "0.0.0-local",
     "description": "Express server for Kapeta SDK",
     "type": "commonjs",
     "exports": {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -3,62 +3,30 @@ export type MainTemplateParams = { baseUrl: string; styles: string; scripts: str
 
 export interface Templates<Req extends Request = Request, Res extends Response = Response> {
     /**
-     * Renders main html template. Receives params with baseUrl, styles and scripts.
-     *
-     * All of them should be rendered as-is, without any escaping for the renderer to work.
-     */
-    renderMain(req: Req, res: Res, params: MainTemplateParams): string;
-
-    /**
      * Renders script link - used in both dev and prod mode
      */
-    renderScript(req: Req, res: Res, src: string): string;
+    renderScript: (req: Req, res: Res, src: string) => string;
 
     /**
      * Renders stylesheet link - only used in prod mode
      */
-    renderStylesheet(req: Req, res: Res, src: string): string;
-
-    /**
-     * Renders inline style - only used in dev mode
-     */
-    renderInlineStyle(req: Req, res: Res, style: string): string;
+    renderStylesheet: (req: Req, res: Res, src: string) => string;
 }
 
 export type TemplatesOverrides = Partial<Templates>;
 
 export const DefaultTemplates: Templates = {
-    renderMain(req: Request, res: Response, params: MainTemplateParams): string {
-        return `<!DOCTYPE html>
-            <html lang="en-US">
-              <head>
-                <title></title>
-                <meta charset="utf-8" />
-                <base href="${params.baseUrl}" />
-                <link rel='shortcut icon' type="image/svg+xml" href='/assets/images/favicon.svg' />
-                ${params.styles}
-              </head>
-              <body>
-                ${params.scripts}
-              </body>
-            </html>`;
-    },
     renderScript(req: Request, res: Response, src: string): string {
         return `<script src="${src}"></script>`;
     },
     renderStylesheet(req: Request, res: Response, src: string): string {
         return `<link rel="stylesheet" href="${src}" />`;
     },
-    renderInlineStyle(req: Request, res: Response, style: string): string {
-        return `<style>${style}</style>`;
-    },
 };
 
 export function asTemplates(templates?: TemplatesOverrides): Templates {
     return {
-        renderMain: templates?.renderMain ?? DefaultTemplates.renderMain,
         renderScript: templates?.renderScript ?? DefaultTemplates.renderScript,
         renderStylesheet: templates?.renderStylesheet ?? DefaultTemplates.renderStylesheet,
-        renderInlineStyle: templates?.renderInlineStyle ?? DefaultTemplates.renderInlineStyle,
     };
 }

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -3,30 +3,20 @@
  * SPDX-License-Identifier: MIT
  */
 
+/// <reference path="../express.d.ts" />
+
 import express, { Express, NextFunction, Request, Response } from 'express';
 import FS from 'fs';
 import * as Path from 'node:path';
 import { asTemplates, TemplatesOverrides } from './templates';
 import { isDevMode } from '../index';
 
-function normalizeAssets(assets: any) {
-    if (!Array.isArray(assets)) {
-        return Object.values(assets);
+const ensureArray = (value: string | string[]): string[] => {
+    if (Array.isArray(value)) {
+        return value;
     }
-
-    return Array.isArray(assets) ? assets : [assets];
-}
-
-function allEntries(assetsByChunkName: any): string[] {
-    const out: string[] = [];
-    Object.values(assetsByChunkName).forEach((assets) => {
-        const normalizedAssets = normalizeAssets(assets);
-        if (Array.isArray(normalizedAssets)) {
-            out.push(...normalizedAssets.filter((asset) => typeof asset === 'string'));
-        }
-    });
-    return out;
-}
+    return [value];
+};
 
 /**
  * Applies webpack handlers to the express app.
@@ -35,76 +25,60 @@ function allEntries(assetsByChunkName: any): string[] {
  * In prod mode, the frontend is served from the dist folder.
  *
  * @param distFolder The absolute path to the dist folder where the build artifacts are located.
- * @param devWebpackConfig The webpack config used in dev mode.
+ * @param webpackConfig The webpack config used in dev mode.
  * @param app The express app to apply the handlers to.
  * @param templateOverrides Optional overrides for the templates used when rendering the HTML page.
  */
 export const applyWebpackHandlers = (
     distFolder: string,
-    devWebpackConfig: any,
+    webpackConfig: any,
     app: Express,
     templateOverrides?: TemplatesOverrides
 ) => {
     const templates = asTemplates(templateOverrides || {});
 
-    // If we catch an error here we want to render it using React
-    app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
-        res.locals.error = err;
-        next();
-    });
-
+    // Set up the two different ways of getting the webpack assets, either devmode rendering,
+    // or by reading the manifest in production mode
     if (isDevMode()) {
         /* eslint-disable */
         console.log('Serving development version');
         const webpack = require('webpack');
         const webpackDevMiddleware = require('webpack-dev-middleware');
-        const compiler = webpack(devWebpackConfig);
-
-        app.get('/favicon.ico', (req, res) => {
-            // If no favicon is found here, return 404
-            // This is to avoid the webpack dev middleware to return the index.html and taking a long time to respond
-            res.sendStatus(404).end();
-        });
+        const compiler = webpack(webpackConfig);
 
         app.use(
-            '/',
             webpackDevMiddleware(compiler, {
-                publicPath: '',
                 serverSideRender: true,
             })
         );
 
         app.use(require('webpack-hot-middleware')(compiler));
 
-        app.get('/*', (req, res) => {
+        // expose asset info on the request to be picked up by renderPage
+        app.use((_req, res, next) => {
             const { devMiddleware } = res.locals.webpack;
-            const outputFileSystem = devMiddleware.outputFileSystem;
-            const jsonWebpackStats = devMiddleware.stats.toJson();
-            const { assetsByChunkName, outputPath } = jsonWebpackStats;
-            const baseUrl = (req.query._kap_basepath ? req.query._kap_basepath : '/').toString();
+            const { entrypoints, publicPath } = devMiddleware.stats.toJson({
+                all: false,
+                entrypoints: true,
+                publicPath: true,
+            });
 
-            if (res.locals?.error) {
-                const status = res.locals?.error?.statusCode ?? 500;
-                res.status(status);
-            }
+            const assets = Object.keys(entrypoints).reduce((agg, pageName) => {
+                const entryAssets: { name: string }[] = entrypoints[pageName].assets;
 
-            res.send(
-                templates.renderMain(req, res, {
-                    baseUrl,
-                    styles: templates.renderInlineStyle(
-                        req,
-                        res,
-                        allEntries(assetsByChunkName)
-                            .filter((path) => path.endsWith('.css') && !path.endsWith('.hot-update.css'))
-                            .map((path) => outputFileSystem.readFileSync(Path.join(outputPath, path)))
-                            .join('\n')
-                    ),
-                    scripts: allEntries(assetsByChunkName)
-                        .filter((path) => path.endsWith('.js') && !path.endsWith('.hot-update.js'))
-                        .map((path) => templates.renderScript(req, res, path))
-                        .join('\n'),
-                })
-            );
+                agg[pageName] = {
+                    js: entryAssets
+                        .filter((chunk) => chunk.name.endsWith('.js'))
+                        .map((chunk) => `${publicPath}${chunk.name}`),
+                    css: entryAssets
+                        .filter((chunk) => chunk.name.endsWith('.css'))
+                        .map((chunk) => `${publicPath}${chunk.name}`),
+                };
+                return agg;
+            }, {} as { [key: string]: { js: string[]; css: string[] } });
+
+            res.locals.webpackAssets = assets;
+            next();
         });
 
         /* eslint-enable */
@@ -117,7 +91,6 @@ export const applyWebpackHandlers = (
             );
             process.exit(1);
         }
-
         const assetsDataFile = Path.join(distFolder, 'assets.json');
         if (!FS.existsSync(assetsDataFile)) {
             console.error(
@@ -126,31 +99,61 @@ export const applyWebpackHandlers = (
             );
             process.exit(1);
         }
+        app.use(
+            webpackConfig.output.publicPath || '/',
+            express.static(distFolder, { index: false, immutable: true, maxAge: 60 * 60 * 24 * 365 * 1000 })
+        );
 
-        const assets = JSON.parse(FS.readFileSync(assetsDataFile).toString());
-        app.use(express.static(distFolder));
-
-        app.get('/*', (req, res) => {
-            const baseUrl = (req.query._kap_basepath ? req.query._kap_basepath : '/').toString();
-
-            if (res.locals?.error) {
-                const status = res.locals?.error?.statusCode ?? 500;
-                res.status(status);
-            }
-
-            res.send(
-                templates.renderMain(req, res, {
-                    baseUrl,
-                    styles: allEntries(assets)
-                        .filter((path) => path.endsWith('.css'))
-                        .map((path) => templates.renderStylesheet(req, res, path))
-                        .join('\n'),
-                    scripts: allEntries(assets)
-                        .filter((path) => path.endsWith('.js') && !path.endsWith('.hot-update.js'))
-                        .map((path) => templates.renderScript(req, res, path))
-                        .join('\n'),
-                })
-            );
+        // expose asset info on the request to be picked up by renderPage
+        const assets = JSON.parse(FS.readFileSync(assetsDataFile, 'utf-8'));
+        app.use((_req, res, next) => {
+            res.locals.webpackAssets = assets;
+            next();
         });
     }
+
+    app.use((req, res, next) => {
+        // Method to pass templateProps to the render method, without rendering immediately
+        function setRenderValue(obj: { [key: string]: any }): void;
+        function setRenderValue(key: string, value: any): void;
+        function setRenderValue(key: string | { [key: string]: any }, value?: any): void {
+            res.locals.templateProps = res.locals.templateProps || {};
+            if (typeof key === 'object') {
+                Object.entries(key).forEach(([keyX, valueX]) => res.setRenderValue(keyX, valueX));
+            } else if (typeof key === 'string') {
+                res.locals.templateProps[key] = value;
+            }
+        }
+        res.setRenderValue = setRenderValue;
+
+        // TODO: idea; viewName could be a kapeta page
+        res.renderPage = (pageName: string, options: any) => {
+            // const publicPath = webpackConfig.output.publicPath as string;
+            const baseUrl = (req.query._kap_basepath ? req.query._kap_basepath : '/').toString();
+            // const basePath = publicPath.endsWith('/') ? publicPath : publicPath + '/';
+
+            const webpackAssets: { [key: string]: { js: string | string[]; css: string | string[] } } =
+                res.locals.webpackAssets;
+
+            if (!(pageName in res.locals.webpackAssets)) {
+                // TODO: nicer error to point to the kapeta pages
+                throw new Error('Invalid page render, page not found in asset map');
+            }
+
+            res.render(options?.viewName || pageName, {
+                ...res.locals.templateProps,
+                ...options,
+                baseUrl,
+                styles: ensureArray(webpackAssets[pageName].css)
+                    .filter((path) => !path.endsWith('.hot-update.css'))
+                    .map((path) => templates.renderStylesheet(req, res, path))
+                    .join('\n'),
+                scripts: ensureArray(webpackAssets[pageName].js)
+                    .filter((path) => !path.endsWith('.hot-update.js'))
+                    .map((path) => templates.renderScript(req, res, path))
+                    .join('\n'),
+            });
+        };
+        next();
+    });
 };


### PR DESCRIPTION
This is a proposal to move the webpack integration to a pre-route middleware, and expose a webpack aware render method (`res.renderPage`).

Example (also updated in Readme.md):

```ts
// Set up webpack middleware and render methods
const DIST_DIR = Path.resolve(__dirname, "../dist");
const webpackConfig = require("../webpack.development.config");
server.configureFrontend(DIST_DIR, webpackConfig);

// Set up templating
const hbs = createHandlebars({
    extname: '.hbs',
    defaultLayout: false,
    helpers: {
        // Recommended helper to serialize values in handlebars
        toJSON: (obj: any) => JSON.stringify(obj),
    },
});
server.express().engine('handlebars', hbs.engine);
server.express().set('views', Path.resolve(__dirname, "../templates"));
server.express().set('view engine', 'handlebars');

server.get('/', async (req, res, next) => {
    // render the main template e.g. templates/main.hbs
    await server.renderPage('main');
});
```

This setup allows the handlers in the downstream routes to call `renderApp`, to respond as they wish. This is much closer to how templates and rendering normally works in ExpressJS.

## Notes

- Removes inline styles during development, since they can create path issues with any images / urls, and present a difference in behavior between prod and dev.
- Uses express view engine (handlebars) instead of string methods.
- Breaking change: requires migration to templates and explicit rendering of the app.