### PR TITLE
fix: export express/webpack method types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ const HEALTH_ENDPOINT = '/.kapeta/health';
 
 export * from './src/helpers';
 export * from './src/templates';
+export type * from './src/webpack';
 
 export type ServerOptions = {
     disableErrorHandling?: boolean;

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -28,6 +28,7 @@ const ensureArray = (value: string | string[]): string[] => {
  * @param webpackConfig The webpack config used in dev mode.
  * @param app The express app to apply the handlers to.
  * @param templateOverrides Optional overrides for the templates used when rendering the HTML page.
+ * @internal
  */
 export const applyWebpackHandlers = (
     distFolder: string,


### PR DESCRIPTION
Makes typescript include the custom methods correctly. 🎉 