### PR TITLE
fix: ensure relative paths for assets and guard against root dist path

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -101,18 +101,6 @@ export const applyWebpackHandlers = (
             );
             process.exit(1);
         }
-        const distPath = webpackConfig.output.publicPath || '/';
-        app.use(
-            distPath,
-            express.static(distFolder, {
-                index: false,
-                immutable: true,
-                maxAge: 60 * 60 * 24 * 365 * 1000,
-                // Treat not found as a 404, unless we're serving from the root,
-                // in which case we want to fall through to the rest of the routes
-                fallthrough: distPath !== '/',
-            })
-        );
 
         // expose asset info on the request to be picked up by renderPage
         const assets = JSON.parse(FS.readFileSync(assetsDataFile, 'utf-8'));
@@ -166,4 +154,17 @@ export const applyWebpackHandlers = (
         };
         next();
     });
+
+    const distPath = webpackConfig.output.publicPath || '/';
+    app.use(
+        distPath,
+        express.static(distFolder, {
+            index: false,
+            immutable: true,
+            maxAge: 60 * 60 * 24 * 365 * 1000,
+            // Treat not found as a 404, unless we're serving from the root,
+            // in which case we want to fall through to the rest of the routes
+            fallthrough: distPath !== '/',
+        })
+    );
 };

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -101,14 +101,16 @@ export const applyWebpackHandlers = (
             );
             process.exit(1);
         }
+        const distPath = webpackConfig.output.publicPath || '/';
         app.use(
-            webpackConfig.output.publicPath || '/',
+            distPath,
             express.static(distFolder, {
                 index: false,
                 immutable: true,
                 maxAge: 60 * 60 * 24 * 365 * 1000,
-                // Treat not found as a 404
-                fallthrough: false,
+                // Treat not found as a 404, unless we're serving from the root,
+                // in which case we want to fall through to the rest of the routes
+                fallthrough: distPath !== '/',
             })
         );
 
@@ -154,11 +156,11 @@ export const applyWebpackHandlers = (
                 baseUrl,
                 styles: ensureArray(webpackAssets[pageName].css)
                     .filter((path) => !path.endsWith('.hot-update.css'))
-                    .map((path) => templates.renderStylesheet(req, res, path))
+                    .map((path) => templates.renderStylesheet(req, res, path.replace(/^\//, '')))
                     .join('\n'),
                 scripts: ensureArray(webpackAssets[pageName].js)
                     .filter((path) => !path.endsWith('.hot-update.js'))
-                    .map((path) => templates.renderScript(req, res, path))
+                    .map((path) => templates.renderScript(req, res, path.replace(/^\//, '')))
                     .join('\n'),
             });
         };


### PR DESCRIPTION
This make sure imports work with `basePath` - i.e. relative imports will use the basepath, but not if they have leading slash.

Also guards against misconfiguration, where an empty or `/` publicpath in webpack will block all other requests to the app.